### PR TITLE
Added a nodejs server example

### DIFF
--- a/servers/nodejs/.gitignore
+++ b/servers/nodejs/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/servers/nodejs/package.json
+++ b/servers/nodejs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "multipart-server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "busboy": "^0.2.9"
+  }
+}

--- a/servers/nodejs/server.js
+++ b/servers/nodejs/server.js
@@ -1,0 +1,47 @@
+// Node.js requires a third party library to do multipart parsing
+// This is ostly taken from the example at https://github.com/mscdex/busboy
+
+var http = require('http');
+
+var Busboy = require('busboy');
+
+http.createServer(function(req, res) {
+  if (req.method === 'POST') {
+    var busboy = new Busboy({ headers: req.headers });
+
+    var files = {};
+    var fields = {};
+
+    busboy.on('file', function(fieldname, file, filename, encoding, mimetype) {
+      files[fieldname] = files[fieldname] || [];
+      files[fieldname].push(filename);
+
+      file.on('data', function(data) {
+        console.log('File [' + fieldname + '] got ' + data.length + ' bytes');
+      });
+      file.on('end', function() {
+        console.log('File [' + fieldname + '] Finished');
+      });
+    });
+
+    busboy.on('field', function(fieldname, val, fieldnameTruncated, valTruncated) {
+      fields[fieldname] = fields[fieldname] || [];
+      fields[fieldname].push(val);
+    });
+
+    busboy.on('finish', function() {
+      console.log('Files:', files);
+      console.log('Fields:', fields);
+
+      res.writeHead(200);
+      res.end();
+    });
+
+    req.pipe(busboy);
+  } else {
+    res.writeHead(400);
+    res.end();
+  }
+}).listen(8000, function() {
+  console.log('Listening for requests');
+});


### PR DESCRIPTION
Here's a quick and simple node.js example. Sorry that it's a bit more verbose than the rest – one can probably get it a bit smaller, but this was a quick one – mostly based on the example in the README at https://github.com/mscdex/busboy, which is the library that https://github.com/expressjs/multer uses, which in turn is what I use in https://github.com/voxpelli/node-micropub-express
